### PR TITLE
Update lexik_jwt_authentication version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/doctrine-bundle": "2.8.*",
         "doctrine/doctrine-migrations-bundle": "3.2.*",
         "doctrine/orm": "2.14.*",
-        "lexik/jwt-authentication-bundle": "2.18.*",
+        "lexik/jwt-authentication-bundle": "2.19.*",
         "nelmio/cors-bundle": "2.2.*",
         "phpdocumentor/reflection-docblock": "5.3.*",
         "phpstan/phpdoc-parser": "1.16.*",


### PR DESCRIPTION
This package of version should be update from 2.18 to 2.19 following this source.

Source: https://github.com/api-platform/api-platform/issues/2505#:~:text=I%20have%20manually%20set%20in%20composer.json%20the%20version%20to%202.19%20and%20I%20don%27t%20have%20to%20comment%20the%20lines%20anymore.